### PR TITLE
AGVFM-70 Make costmap converter ready for multiple agvs

### DIFF
--- a/costmap_converter/launch/launch_converter.py
+++ b/costmap_converter/launch/launch_converter.py
@@ -53,7 +53,6 @@ def generate_launch_description():
             parameters=[{"rolling_window": False,
                          "map_topic": "/occupancy_grid",
                          "wait_tf_on_activate": False,
-                         "update_frequency": 0.0,
                          "static_layer.subscribe_to_updates": True,
                          "static_layer.map_subscribe_transient_local": True
                          }],

--- a/costmap_converter/launch/launch_converter.py
+++ b/costmap_converter/launch/launch_converter.py
@@ -49,9 +49,11 @@ def generate_launch_description():
             condition=IfCondition(use_namespace),
             namespace=namespace),
         launch_ros.actions.Node(
-            package='costmap_converter', node_executable='standalone_converter', output='screen',
+            package='costmap_converter', executable='standalone_converter', output='screen',
             parameters=[{"rolling_window": False,
                          "map_topic": "/occupancy_grid",
+                         "wait_tf_on_activate": False,
+                         "update_frequency": 0.0,
                          "static_layer.subscribe_to_updates": True,
                          "static_layer.map_subscribe_transient_local": True
                          }],

--- a/costmap_converter/launch/launch_converter_simulation.py
+++ b/costmap_converter/launch/launch_converter_simulation.py
@@ -48,9 +48,11 @@ def generate_launch_description():
             condition=IfCondition(use_namespace),
             namespace=namespace),
         launch_ros.actions.Node(
-            package='costmap_converter', node_executable='standalone_converter', output='screen',
+            package='costmap_converter', executable='standalone_converter', output='screen',
             parameters=[{"rolling_window": False,
-                         "map_topic": ("/costmap_node/map"),
+                         "map_topic": "/agv1/global_costmap/costmap_node/map",
+                         "wait_tf_on_activate": False,
+                         "update_frequency": 0.0,
                          "static_layer.subscribe_to_updates": True,
                          "static_layer.map_subscribe_transient_local": True
                          }],                                                                             

--- a/costmap_converter/launch/launch_converter_simulation.py
+++ b/costmap_converter/launch/launch_converter_simulation.py
@@ -52,7 +52,6 @@ def generate_launch_description():
             parameters=[{"rolling_window": False,
                          "map_topic": "/agv1/global_costmap/costmap_node/map",
                          "wait_tf_on_activate": False,
-                         "update_frequency": 0.0,
                          "static_layer.subscribe_to_updates": True,
                          "static_layer.map_subscribe_transient_local": True
                          }],                                                                             


### PR DESCRIPTION
---

## Basic Info

| Info | Make costmap converter ready for multiple agvs |
| ------ | ----------- |
| Ticket(s) this addresses   | https://lvserv01.logivations.com/browse/AGVFM-70 |
| Primary OS tested on | Ubuntu |
| Robotic platform tested on | W2MO simulation |

---

## Description of contribution in a few bullet points
* for launch files added use of the new costmap_2d_ros parameter that tells not to wait on tf transform on activation
* for simulation launcher changed costmap topic
* changed node_executable to executable as former is deprecated
